### PR TITLE
M2M - CLA0003-12 - Update PureFTPD To 1.0.43

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,7 +32,7 @@ default['cookbook_clarus']['jetty']['home_dir'] = "/opt/solr-#{node['cookbook_cl
 default['cookbook_clarus']['jetty']['log_dir'] = "/var/log/solr"
 
 default['cookbook_clarus']['ftp_root'] = "/home/apps/#{node['cookbook_clarus']['appname']}/current/storage"
-default['cookbook_clarus']['pure-ftpd']['url'] = 'http://download.pureftpd.org/pub/pure-ftpd/releases/pure-ftpd-1.0.39.tar.gz'
+default['cookbook_clarus']['pure-ftpd']['url'] = 'http://download.pureftpd.org/pub/pure-ftpd/releases/pure-ftpd-1.0.43.tar.gz'
 
 default['cookbook_clarus']['newrelic']['license_key'] = nil
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'fred.thompson@buildempire.co.uk'
 license          'Apache 2.0'
 description      'The Clarus server cookbook, ready for the Clarus application deployment.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.9'
+version          '0.4.0'
 
 recipe 'cookbook_clarus', 'The Clarus server cookbook, ready for the Clarus application deployment.'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'fred.thompson@buildempire.co.uk'
 license          'Apache 2.0'
 description      'The Clarus server cookbook, ready for the Clarus application deployment.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.0'
+version          '0.4.1'
 
 recipe 'cookbook_clarus', 'The Clarus server cookbook, ready for the Clarus application deployment.'
 

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -10,9 +10,9 @@ rb_version = node['cookbook_clarus']['ruby']['version']
 include_recipe 'rbenv::default'
 include_recipe 'rbenv::ruby_build'
 
-rbenv_ruby rb_version
-# Removing this line as it still doesn't work, but I really think we need to sort this.
-# rbenv_global rb_version
+rbenv_ruby rb_version do
+  global(true)
+end
 rbenv_gem 'bundler' do
   ruby_version rb_version
 end


### PR DESCRIPTION
CLA0003-12 - Update PureFTPD To 1.0.43

As the cookbook is currently failing as the URL doesn't exist to the old version.

#CLA0003-12 Fixed