### PR TITLE
M2M - 0.5.0 - CLA0003-564 - Ohai Lock Removal

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'fred.thompson@buildempire.co.uk'
 license          'Apache 2.0'
 description      'The Clarus server cookbook, ready for the Clarus application deployment.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.13'
+version          '0.4.14'
 
 recipe 'cookbook_clarus', 'The Clarus server cookbook, ready for the Clarus application deployment.'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'fred.thompson@buildempire.co.uk'
 license          'Apache 2.0'
 description      'The Clarus server cookbook, ready for the Clarus application deployment.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.14'
+version          '0.5.0'
 
 recipe 'cookbook_clarus', 'The Clarus server cookbook, ready for the Clarus application deployment.'
 
@@ -12,7 +12,7 @@ recipe 'cookbook_clarus', 'The Clarus server cookbook, ready for the Clarus appl
   supports os
 end
 
-%w{appbox apt build-essential database imagemagick logrotate nginx postgresql
-   rbenv ruby_build runit sqlite unicorn wkhtmltopdf-update}.each do |cb|
+%w{appbox apt build-essential chef_nginx database imagemagick logrotate postgresql
+   ruby_rbenv runit sqlite unicorn wkhtmltopdf-update}.each do |cb|
   depends cb
 end

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -8,4 +8,4 @@ node.set['nginx']['source']['checksum'] = '1af2eb956910ed4b11aaf525a81bc37e13590
 node.set['nginx']['source']['version']  = node['nginx']['version']
 node.set['nginx']['source']['url']      = "http://nginx.org/download/nginx-#{node['nginx']['source']['version']}.tar.gz"
 
-include_recipe 'nginx::source'
+include_recipe 'chef_nginx::source'

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -7,12 +7,10 @@
 
 rb_version = node['cookbook_clarus']['ruby']['version']
 
-include_recipe 'rbenv::default'
-include_recipe 'rbenv::ruby_build'
+rbenv_system_install 'foo'
+rbenv_ruby rb_version
+rbenv_global rb_version
 
-rbenv_ruby rb_version do
-  global(true)
-end
 rbenv_gem 'bundler' do
-  ruby_version rb_version
+  rbenv_version rb_version
 end

--- a/recipes/wkhtmltopdf.rb
+++ b/recipes/wkhtmltopdf.rb
@@ -4,6 +4,7 @@
 #
 
 # Replace the dependency packages for Ubuntu 16.06 by replacing libssl0.9.8 with libssl1.0.0
+node.set['wkhtmltopdf-update']['mirror_url'] = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/#{node['wkhtmltopdf-update']['version']}/#{node['wkhtmltopdf-update']['package']}"
 node.set['wkhtmltopdf-update']['dependency_packages'] = %w(libfontconfig1 libssl1.0.0 libxext6 libxrender1 fontconfig libjpeg8 xfonts-base xfonts-75dpi)
 
 # Install wkhtmltopdf itself


### PR DESCRIPTION
What was originally an attempt to remove the oahi lock required for Clarus actually turned into a nginx and rbenv cookbook change too. The previous implementations of these cookbooks had not been updated in many years and were hitting problems with Chef 13, so I've replaced them with maintained versions. Hopefully, nothing should really change.

Upped the version of 0.5.0 to signify the change.