### PR TITLE
CLA0003-890 - Wkhtmltopdf Repository Switch

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'fred.thompson@buildempire.co.uk'
 license          'Apache 2.0'
 description      'The Clarus server cookbook, ready for the Clarus application deployment.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.5.2'
+version          '0.5.3'
 
 recipe 'cookbook_clarus', 'The Clarus server cookbook, ready for the Clarus application deployment.'
 

--- a/recipes/wkhtmltopdf.rb
+++ b/recipes/wkhtmltopdf.rb
@@ -4,7 +4,6 @@
 #
 
 # Replace the dependency packages for Ubuntu 16.06 by replacing libssl0.9.8 with libssl1.0.0
-node.set['wkhtmltopdf-update']['mirror_url'] = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/#{node['wkhtmltopdf-update']['version']}/#{node['wkhtmltopdf-update']['package']}"
 node.set['wkhtmltopdf-update']['dependency_packages'] = %w(libfontconfig1 libssl1.0.0 libxext6 libxrender1 fontconfig libjpeg8 xfonts-base xfonts-75dpi)
 
 # Install wkhtmltopdf itself


### PR DESCRIPTION
As we're using the BuildEmpire fork of this now, we don't need the mirror url.