### PR TITLE
CLA0003-952 - PureFTP Version Default To 1.0.47

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,6 @@ default['cookbook_clarus']['ruby']['version'] = '2.3.3'
 default['cookbook_clarus']['app_root'] = "/home/apps/#{node['cookbook_clarus']['appname']}"
 default['cookbook_clarus']['shared_root'] = "#{node['cookbook_clarus']['app_root']}/shared"
 default['cookbook_clarus']['ftp_root'] = "#{node['cookbook_clarus']['shared_root']}/storage"
-default['cookbook_clarus']['pure-ftpd']['url'] = 'http://download.pureftpd.org/pub/pure-ftpd/releases/pure-ftpd-1.0.44.tar.gz'
+default['cookbook_clarus']['pure-ftpd']['url'] = 'http://download.pureftpd.org/pub/pure-ftpd/releases/pure-ftpd-1.0.47.tar.gz'
 default['cookbook_clarus']['pure-ftpd']['version'] = '1.0.44'
 default['build-essential']['compile_time'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'fred.thompson@buildempire.co.uk'
 license          'Apache 2.0'
 description      'The Clarus server cookbook, ready for the Clarus application deployment.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.6.6'
+version          '0.6.7'
 
 recipe 'cookbook_clarus', 'The Clarus server cookbook, ready for the Clarus application deployment.'
 


### PR DESCRIPTION
Updated the default version of PureFTP to one that is available so the cookbook works as expected.

CLA0003-952