### PR TITLE
M2M - 0.6.9. - CLA0003-970 - Data Import On Demand

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,5 +21,5 @@ default['cookbook_clarus']['app_root'] = "/home/apps/#{node['cookbook_clarus']['
 default['cookbook_clarus']['shared_root'] = "#{node['cookbook_clarus']['app_root']}/shared"
 default['cookbook_clarus']['ftp_root'] = "#{node['cookbook_clarus']['shared_root']}/storage"
 default['cookbook_clarus']['pure-ftpd']['url'] = 'http://download.pureftpd.org/pub/pure-ftpd/releases/pure-ftpd-1.0.47.tar.gz'
-default['cookbook_clarus']['pure-ftpd']['version'] = '1.0.44'
+default['cookbook_clarus']['pure-ftpd']['version'] = '1.0.47'
 default['build-essential']['compile_time'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,4 +22,6 @@ default['cookbook_clarus']['shared_root'] = "#{node['cookbook_clarus']['app_root
 default['cookbook_clarus']['ftp_root'] = "#{node['cookbook_clarus']['shared_root']}/storage"
 default['cookbook_clarus']['pure-ftpd']['url'] = 'http://download.pureftpd.org/pub/pure-ftpd/releases/pure-ftpd-1.0.47.tar.gz'
 default['cookbook_clarus']['pure-ftpd']['version'] = '1.0.47'
+default['cookbook_clarus']['redis']['host'] = 'localhost'
+default['cookbook_clarus']['redis']['port'] = '6379'
 default['build-essential']['compile_time'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'fred.thompson@buildempire.co.uk'
 license          'Apache 2.0'
 description      'The Clarus server cookbook, ready for the Clarus application deployment.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.6.7'
+version          '0.6.8'
 
 recipe 'cookbook_clarus', 'The Clarus server cookbook, ready for the Clarus application deployment.'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'fred.thompson@buildempire.co.uk'
 license          'Apache 2.0'
 description      'The Clarus server cookbook, ready for the Clarus application deployment.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.6.8'
+version          '0.6.9'
 
 recipe 'cookbook_clarus', 'The Clarus server cookbook, ready for the Clarus application deployment.'
 

--- a/recipes/ftpd.rb
+++ b/recipes/ftpd.rb
@@ -3,6 +3,37 @@ gem_package "bcrypt" do
   action :install
 end
 
+# Ftp services need PG system wide.
+postgresql_pg_gem 'install postgresql gem' do
+  ruby_binary '/usr/local/rbenv/shims/ruby'
+end
+
+# Ftp services need Redis system wide.
+gem_package 'redis' do
+  action :install
+  version '<4'
+end
+
+# Ftp services need sinatra system wide (as resque needs it).
+gem_package 'sinatra' do
+  action :install
+end
+
+# Ftp services need Resque system wide.
+gem_package 'resque' do
+  action :install
+end
+
+# Ftp services need Resque-scheduler system wide.
+gem_package 'resque-scheduler' do
+  action :install
+end
+
+# Ftp services need as-duration system wide (to schedule tasks a little easier).
+gem_package 'as-duration' do
+  action :install
+end
+
 remote_file "/tmp/pure-ftpd-#{node['cookbook_clarus']['pure-ftpd']['version']}.tar.gz" do
   source node['cookbook_clarus']['pure-ftpd']['url']
 end
@@ -11,7 +42,7 @@ bash 'Download Pure-FTPD' do
   code <<-EOH
     sudo tar -C /tmp -xzf /tmp/pure-ftpd-#{node['cookbook_clarus']['pure-ftpd']['version']}.tar.gz
     cd /tmp/pure-ftpd-#{node['cookbook_clarus']['pure-ftpd']['version']}
-    sudo ./configure --with-extauth
+    sudo ./configure --with-extauth --with-uploadscript
     sudo make
     sudo make install
   EOH
@@ -32,6 +63,13 @@ template '/etc/pure-ftpd/ftp-auth-handler' do
   mode '0755'
 end
 
+template '/etc/pure-ftpd/ftp-upload-script' do
+  source 'ftp-upload-script.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end
+
 systemd_unit "pure-ftpd-authd.service" do
   enabled true
   active true
@@ -39,14 +77,25 @@ systemd_unit "pure-ftpd-authd.service" do
   action [:create]
 end
 
+systemd_unit "pure-ftpd-uploadscript.service" do
+  enabled true
+  active true
+  content "[Unit]\nDescription=Pure-FTPd-Uploadscript\nAfter=network.target\n\n[Service]\nExecStart=/usr/local/sbin/pure-uploadscript -r /etc/pure-ftpd/ftp-upload-script\nRestart=always\n\n[Install]\nWantedBy=multi-user.target"
+  action [:create]
+end
+
 systemd_unit "pure-ftpd.service" do
   enabled true
   active true
-  content "[Unit]\nDescription=Pure-FTPd\nAfter=network.target\n\n[Service]\nExecStart=/usr/local/sbin/pure-ftpd -lextauth:/var/run/ftpd.sock -p 50000:50400\nRestart=always\n\n[Install]\nWantedBy=multi-user.target"
+  content "[Unit]\nDescription=Pure-FTPd\nAfter=network.target\n\n[Service]\nExecStart=/usr/local/sbin/pure-ftpd -lextauth:/var/run/ftpd.sock -p 50000:50400 -o\nRestart=always\n\n[Install]\nWantedBy=multi-user.target"
   action [:create]
 end
 
 systemd_unit "pure-ftpd-authd.service" do
+  action [:enable, :start]
+end
+
+systemd_unit "pure-ftpd-uploadscript.service" do
   action [:enable, :start]
 end
 

--- a/recipes/postgresql.rb
+++ b/recipes/postgresql.rb
@@ -51,8 +51,3 @@ if install_db
   end
 
 end
-
-# Ftp services need PG system wide.
-postgresql_pg_gem 'install postgresql gem' do
-  ruby_binary '/usr/local/rbenv/shims/ruby'
-end

--- a/templates/default/ftp-auth-handler.erb
+++ b/templates/default/ftp-auth-handler.erb
@@ -41,6 +41,7 @@ if encrypted_password == authd_password
 
   open(log_file, 'a') do |f|
     f.puts "FTP Login Successful"
+    f.puts "Attempting to access #{target_dir}"
   end
 
   puts 'auth_ok:1'

--- a/templates/default/ftp-upload-script.erb
+++ b/templates/default/ftp-upload-script.erb
@@ -1,0 +1,31 @@
+#!/usr/bin/env /usr/local/rbenv/shims/ruby
+
+require 'fileutils'
+
+apps_dir = '<%= node['appbox']['apps_dir'] %>'
+appname = '<%= node['cookbook_clarus']['appname'] %>'
+log_file = ::File.join(apps_dir, appname, 'shared', 'log', 'ftp.log')
+
+open(log_file, 'a') do |f|
+  f.puts "FTP File Upload: Attempting to add the following file to the queue:"
+  f.puts "#{ARGV[0]}"
+end
+
+require 'redis'
+require 'resque'
+require 'resque-scheduler'
+require 'resque/scheduler/server'
+require 'as-duration'
+
+redis_host = '<%= node['cookbook_clarus']['redis']['host'] %>'
+redis_port = <%= node['cookbook_clarus']['redis']['port'] %>
+
+$redis = Redis.new(host: redis_host, port: redis_port)
+Resque.redis = $redis
+
+Resque.enqueue_at_with_queue(:ftp, 30.seconds.from_now, 'DataImporter', ARGV[0])
+
+open(log_file, 'a') do |f|
+  f.puts "FTP File Upload: Successfully added the following uploaded file to the queue:"
+  f.puts "#{ARGV[0]}"
+end


### PR DESCRIPTION
Took advantage of the upload hook that Pure FTP give us, and calling a ruby script that adds a single processing task line to resque, with a 30 seconds delay. From this, we will then be able to receive information about individual failures, and see them process in order, potentially by multiple workers.

The delay is just so EFS can catchup throughout the workers, so the file exists when try to process it, but also feels nicer to the user that the files don't immediately disappear.

You should be able to see files ready to process in the Delayed tab on Resque.

CLA0003-970